### PR TITLE
Attach python lifetime to shared_ptr passed to C++

### DIFF
--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -664,6 +664,14 @@ struct holder_retriever<std::shared_ptr<T>> {
     };
 
     static auto get_derivative_holder(const value_and_holder &v_h) -> std::shared_ptr<T> {
+        // If there's no trampoline class, nothing special needed
+        if (!v_h.inst->has_alias) {
+            return v_h.template holder<std::shared_ptr<T>>();
+        }
+
+        // If there's a trampoline class, ensure the python side of the object doesn't
+        // die until the C++ portion also dies
+        //
         // The shared_ptr is always given to C++ code, so construct a new shared_ptr
         // that is given a custom deleter. The custom deleter increments the python
         // reference count to bind the python instance lifetime with the lifetime

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "gil.h"
 #include "pytypes.h"
 #include "detail/common.h"
 #include "detail/descr.h"
@@ -641,6 +642,42 @@ struct holder_helper {
     static auto get(const T &p) -> decltype(p.get()) { return p.get(); }
 };
 
+/// Another helper class for holders that helps construct derivative holders from
+/// the original holder
+template <typename T>
+struct holder_retriever {
+    static auto get_derivative_holder(const value_and_holder &v_h) -> decltype(v_h.template holder<T>()) {
+        return v_h.template holder<T>();
+    }
+};
+
+template <typename T>
+struct holder_retriever<std::shared_ptr<T>> {
+    struct shared_ptr_deleter {
+        // Note: deleter destructor fails on MSVC 2015 and GCC 4.8, so we manually
+        // call dec_ref here instead
+        handle ref;
+        void operator()(T *) {
+            gil_scoped_acquire gil;
+            ref.dec_ref();
+        }
+    };
+
+    static auto get_derivative_holder(const value_and_holder &v_h) -> std::shared_ptr<T> {
+        // The shared_ptr is always given to C++ code, so construct a new shared_ptr
+        // that is given a custom deleter. The custom deleter increments the python
+        // reference count to bind the python instance lifetime with the lifetime
+        // of the shared_ptr.
+        //
+        // This enables things like passing the last python reference of a subclass to a
+        // C++ function without the python reference dying.
+        //
+        // Reference cycles will cause a leak, but this is a limitation of shared_ptr
+        return std::shared_ptr<T>((T*)v_h.value_ptr(),
+            shared_ptr_deleter{handle((PyObject*)v_h.inst).inc_ref()});
+    }
+};
+
 /// Type caster for holder types like std::shared_ptr, etc.
 /// The SFINAE hook is provided to help work around the current lack of support
 /// for smart-pointer interoperability. Please consider it an implementation
@@ -683,7 +720,7 @@ protected:
     bool load_value(value_and_holder &&v_h) {
         if (v_h.holder_constructed()) {
             value = v_h.value_ptr();
-            holder = v_h.template holder<holder_type>();
+            holder = holder_retriever<holder_type>::get_derivative_holder(v_h);
             return true;
         }
         throw cast_error("Unable to cast from non-held to held instance (T& to Holder<T>) "

--- a/include/pybind11/cast.h
+++ b/include/pybind11/cast.h
@@ -665,7 +665,7 @@ struct holder_retriever<std::shared_ptr<T>> {
 
     static auto get_derivative_holder(const value_and_holder &v_h) -> std::shared_ptr<T> {
         // If there's no trampoline class, nothing special needed
-        if (!v_h.inst->has_alias) {
+        if (!v_h.inst->is_alias) {
             return v_h.template holder<std::shared_ptr<T>>();
         }
 

--- a/include/pybind11/detail/class.h
+++ b/include/pybind11/detail/class.h
@@ -178,6 +178,8 @@ extern "C" inline PyObject *pybind11_meta_call(PyObject *type, PyObject *args, P
 
     // This must be a pybind11 instance
     auto instance = reinterpret_cast<detail::instance *>(self);
+    // Mark this instance as an instance of an alias class
+    instance->is_alias = instance->has_alias;
 
     // Ensure that the base __init__ function(s) were called
     for (const auto &vh : values_and_holders(instance)) {

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -580,8 +580,10 @@ struct instance {
     bool simple_instance_registered : 1;
     /// If true, get_internals().patients has an entry for this object
     bool has_patients : 1;
-    /// If true, created with an associated alias class (set via `init_instance`)
+    /// If true, the type of this instance has an associated alias class (set via `init_instance`)
     bool has_alias : 1;
+    /// If true, this instance has an associated alias class and was constructed by Python
+    bool is_alias : 1;
 
     /// Initializes all of the above type/values/holders data (but not the instance values themselves)
     void allocate_layout();

--- a/include/pybind11/detail/common.h
+++ b/include/pybind11/detail/common.h
@@ -580,6 +580,8 @@ struct instance {
     bool simple_instance_registered : 1;
     /// If true, get_internals().patients has an entry for this object
     bool has_patients : 1;
+    /// If true, created with an associated alias class (set via `init_instance`)
+    bool has_alias : 1;
 
     /// Initializes all of the above type/values/holders data (but not the instance values themselves)
     void allocate_layout();

--- a/include/pybind11/pybind11.h
+++ b/include/pybind11/pybind11.h
@@ -1630,6 +1630,7 @@ private:
     /// optional pointer to an existing holder to use; if not specified and the instance is
     /// `.owned`, a new holder will be constructed to manage the value pointer.
     static void init_instance(detail::instance *inst, const void *holder_ptr) {
+        inst->has_alias = has_alias;
         auto v_h = inst->get_value_and_holder(detail::get_type_info(typeid(type)));
         if (!v_h.instance_registered()) {
             register_instance(inst, v_h.value_ptr(), v_h.type);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -132,6 +132,7 @@ set(PYBIND11_TEST_FILES
     test_stl_binders.cpp
     test_tagbased_polymorphic.cpp
     test_thread.cpp
+    test_trampoline_shared_ptr_cpp_arg.cpp
     test_union.cpp
     test_virtual_functions.cpp)
 

--- a/tests/test_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_trampoline_shared_ptr_cpp_arg.cpp
@@ -52,4 +52,13 @@ TEST_SUBMODULE(trampoline_shared_ptr_cpp_arg, m) {
         .def("set_object", &SpBaseTester::set_object)
         .def("is_base_used", &SpBaseTester::is_base_used)
         .def_readwrite("obj", &SpBaseTester::m_obj);
+
+    // For testing that a C++ class without an alias does not retain the python
+    // portion of the object
+
+    py::class_<SpGoAway, std::shared_ptr<SpGoAway>>(m, "SpGoAway").def(py::init<>());
+
+    py::class_<SpGoAwayTester>(m, "SpGoAwayTester")
+        .def(py::init<>())
+        .def_readwrite("obj", &SpGoAwayTester::m_obj);
 }

--- a/tests/test_trampoline_shared_ptr_cpp_arg.cpp
+++ b/tests/test_trampoline_shared_ptr_cpp_arg.cpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 The Pybind Development Team.
+// All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+#include "pybind11_tests.h"
+
+namespace {
+
+// For testing whether a python subclass of a C++ object dies when the
+// last python reference is lost
+struct SpBase {
+    // returns true if the base virtual function is called
+    virtual bool is_base_used() { return true; }
+
+    SpBase()               = default;
+    SpBase(const SpBase &) = delete;
+    virtual ~SpBase()      = default;
+};
+
+struct PySpBase : SpBase {
+    bool is_base_used() override { PYBIND11_OVERRIDE(bool, SpBase, is_base_used); }
+};
+
+struct SpBaseTester {
+    std::shared_ptr<SpBase> get_object() const { return m_obj; }
+    void set_object(std::shared_ptr<SpBase> obj) { m_obj = std::move(obj); }
+    bool is_base_used() { return m_obj->is_base_used(); }
+    std::shared_ptr<SpBase> m_obj;
+};
+
+// For testing that a C++ class without an alias does not retain the python
+// portion of the object
+struct SpGoAway {};
+
+struct SpGoAwayTester {
+    std::shared_ptr<SpGoAway> m_obj;
+};
+
+} // namespace
+
+TEST_SUBMODULE(trampoline_shared_ptr_cpp_arg, m) {
+    // For testing whether a python subclass of a C++ object dies when the
+    // last python reference is lost
+
+    py::class_<SpBase, std::shared_ptr<SpBase>, PySpBase>(m, "SpBase")
+        .def(py::init<>())
+        .def("is_base_used", &SpBase::is_base_used);
+
+    py::class_<SpBaseTester>(m, "SpBaseTester")
+        .def(py::init<>())
+        .def("get_object", &SpBaseTester::get_object)
+        .def("set_object", &SpBaseTester::set_object)
+        .def("is_base_used", &SpBaseTester::is_base_used)
+        .def_readwrite("obj", &SpBaseTester::m_obj);
+}

--- a/tests/test_trampoline_shared_ptr_cpp_arg.py
+++ b/tests/test_trampoline_shared_ptr_cpp_arg.py
@@ -64,3 +64,23 @@ def test_shared_ptr_arg_identity():
     tester.set_object(None)
     pytest.gc_collect()
     assert objref() is None
+
+
+def test_shared_ptr_goaway():
+    import weakref
+
+    tester = m.SpGoAwayTester()
+
+    obj = m.SpGoAway()
+    objref = weakref.ref(obj)
+
+    assert tester.obj is None
+
+    tester.obj = obj
+    del obj
+    pytest.gc_collect()
+
+    # python reference is no longer around
+    assert objref() is None
+    # C++ reference is still around
+    assert tester.obj is not None

--- a/tests/test_trampoline_shared_ptr_cpp_arg.py
+++ b/tests/test_trampoline_shared_ptr_cpp_arg.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import pytest
+
+import pybind11_tests.trampoline_shared_ptr_cpp_arg as m
+
+
+def test_shared_ptr_cpp_arg():
+    import weakref
+
+    class PyChild(m.SpBase):
+        def is_base_used(self):
+            return False
+
+    tester = m.SpBaseTester()
+
+    obj = PyChild()
+    objref = weakref.ref(obj)
+
+    # Pass the last python reference to the C++ function
+    tester.set_object(obj)
+    del obj
+    pytest.gc_collect()
+
+    # python reference is still around since C++ has it now
+    assert objref() is not None
+    assert tester.is_base_used() is False
+    assert tester.obj.is_base_used() is False
+    assert tester.get_object() is objref()
+
+
+def test_shared_ptr_cpp_prop():
+    class PyChild(m.SpBase):
+        def is_base_used(self):
+            return False
+
+    tester = m.SpBaseTester()
+
+    # Set the last python reference as a property of the C++ object
+    tester.obj = PyChild()
+    pytest.gc_collect()
+
+    # python reference is still around since C++ has it now
+    assert tester.is_base_used() is False
+    assert tester.obj.is_base_used() is False
+
+
+def test_shared_ptr_arg_identity():
+    import weakref
+
+    tester = m.SpBaseTester()
+
+    obj = m.SpBase()
+    objref = weakref.ref(obj)
+
+    tester.set_object(obj)
+    del obj
+    pytest.gc_collect()
+
+    # python reference is still around since C++ has it
+    assert objref() is not None
+    assert tester.get_object() is objref()
+
+    # python reference disappears once the C++ object releases it
+    tester.set_object(None)
+    pytest.gc_collect()
+    assert objref() is None


### PR DESCRIPTION
- Reference cycles are possible as a result, but shared_ptr is already susceptible to this in C++<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

<!-- Fill in the below block with the expected RestructuredText entry. Delete if no entry needed;
     but do not delete header or rst block if an entry is needed! Will be collected via a script. -->

```rst

```

<!-- If the upgrade guide needs updating, note that here too -->
